### PR TITLE
feat(frontend): configure Angular environment files for dev and production

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -36,6 +36,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "budgets": [
                 {
                   "type": "initial",

--- a/frontend/src/environment/environment.prod.ts
+++ b/frontend/src/environment/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiUrl: 'http://api:8080/api'
+};

--- a/frontend/src/environment/environment.ts
+++ b/frontend/src/environment/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiUrl: 'http://localhost:5000/api'
+};


### PR DESCRIPTION
Adds environment configuration files so the API URL is never hardcoded in source code. All services will reference `environment.apiUrl` rather than a literal URL string.