### PR TITLE
Feature/amelia thermostat strategy

### DIFF
--- a/backend/src/SmartHome.Domain/Device/Thermostat/AutoModeStrategy.cs
+++ b/backend/src/SmartHome.Domain/Device/Thermostat/AutoModeStrategy.cs
@@ -1,0 +1,17 @@
+﻿namespace SmartHome.Domain.Device.Thermostat;
+
+
+/// <summary>
+/// Auto mode — system heats or cools automatically as needed.
+/// Heats when ambient is below desired, cools when above.
+/// </summary>
+public sealed class AutoModeStrategy : IThermostatModeStrategy
+{
+    public ThermostatState Evaluate(int ambient, int desired)
+    {
+        if (ambient < desired) return ThermostatState.Heating;
+        if (ambient > desired) return ThermostatState.Cooling;
+        return ThermostatState.Idle;
+    }
+        
+}

--- a/backend/src/SmartHome.Domain/Device/Thermostat/CoolModeStrategy.cs
+++ b/backend/src/SmartHome.Domain/Device/Thermostat/CoolModeStrategy.cs
@@ -1,0 +1,15 @@
+﻿namespace SmartHome.Domain.Device.Thermostat;
+
+
+/// <summary>
+/// Cooling mode — system may only cool.
+/// Transitions to Cooling when ambient is above desired.
+/// Will never heat even if ambient is lower desired.
+/// </summary>
+public sealed class CoolModeStrategy : IThermostatModeStrategy
+{
+    public ThermostatState Evaluate(int ambient, int desired) =>
+        ambient > desired
+            ? ThermostatState.Cooling
+            : ThermostatState.Idle;
+}

--- a/backend/src/SmartHome.Domain/Device/Thermostat/CoolModeStrategy.cs
+++ b/backend/src/SmartHome.Domain/Device/Thermostat/CoolModeStrategy.cs
@@ -4,7 +4,7 @@
 /// <summary>
 /// Cooling mode — system may only cool.
 /// Transitions to Cooling when ambient is above desired.
-/// Will never heat even if ambient is lower desired.
+/// Will never heat even if ambient is lower than desired.
 /// </summary>
 public sealed class CoolModeStrategy : IThermostatModeStrategy
 {

--- a/backend/src/SmartHome.Domain/Device/Thermostat/HeatModeStrategy.cs
+++ b/backend/src/SmartHome.Domain/Device/Thermostat/HeatModeStrategy.cs
@@ -1,0 +1,15 @@
+﻿namespace SmartHome.Domain.Device.Thermostat;
+
+
+/// <summary>
+/// Heat mode — system may only heat.
+/// Transitions to Heating when ambient is below desired.
+/// Will never cool even if ambient exceeds desired.
+/// </summary>
+public sealed class HeatModeStrategy : IThermostatModeStrategy
+{
+    public ThermostatState Evaluate(int ambient, int desired) =>
+        ambient < desired
+            ? ThermostatState.Heating
+            : ThermostatState.Idle;
+}

--- a/backend/src/SmartHome.Domain/Device/Thermostat/IThermostatModeStrategy.cs
+++ b/backend/src/SmartHome.Domain/Device/Thermostat/IThermostatModeStrategy.cs
@@ -6,7 +6,7 @@
 /// Each mode determines when the thermostat should heat, cool, or idle
 /// based on ambient vs desired temperature.
 /// Implement this interface to add a new mode without modifying any existing code
-/// Open/Closed Principle.
+/// (Open/Closed Principle).
 /// </summary>
 public interface IThermostatModeStrategy
 {

--- a/backend/src/SmartHome.Domain/Device/Thermostat/IThermostatModeStrategy.cs
+++ b/backend/src/SmartHome.Domain/Device/Thermostat/IThermostatModeStrategy.cs
@@ -1,0 +1,19 @@
+﻿namespace SmartHome.Domain.Device.Thermostat;
+
+
+/// <summary>
+/// Defines the contract for thermostat mode behavior.
+/// Each mode determines when the thermostat should heat, cool, or idle
+/// based on ambient vs desired temperature.
+/// Implement this interface to add a new mode without modifying any existing code
+/// Open/Closed Principle.
+/// </summary>
+public interface IThermostatModeStrategy
+{
+    
+    /// <summary>
+    /// Evaluates ambient vs desired temperature and returns
+    /// the appropriate thermostat state for this mode.
+    /// </summary>
+    ThermostatState Evaluate(int ambientTemperature, int desiredTemperature);
+}

--- a/backend/src/SmartHome.Domain/Device/Thermostat/Thermostat.cs
+++ b/backend/src/SmartHome.Domain/Device/Thermostat/Thermostat.cs
@@ -15,10 +15,22 @@ public sealed class Thermostat : Device, IThermostatControllable
     /// </summary>
     public ThermostatState State { get; private set; }
     
+    private ThermostatMode _mode;
+
     /// <summary>
     /// The current mode controlling heating/cooling behavior.
+    /// When set, automatically updates the active strategy so EF Core
+    /// rehydration always produces a consistent state.
     /// </summary>
-    public ThermostatMode Mode { get; private set; }
+    public ThermostatMode Mode
+    {
+        get => _mode;
+        private set
+        {
+            _mode = value;
+            _strategy = Strategies[value];
+        }
+    }
     
     /// <summary>
     /// The target temperature in Fahrenheit. Clamped to 60–80°F.
@@ -34,19 +46,17 @@ public sealed class Thermostat : Device, IThermostatControllable
     private const int MinTemperature = 60;
     private const int MaxTemperature = 80;
 
+    private IThermostatModeStrategy _strategy = null!;
     
     // Strategy map — adding a new mode only requires a new class and entry here.
     // Thermostat.cs never changes — Open/Closed Principle.
     private static readonly Dictionary<ThermostatMode, IThermostatModeStrategy>
-        Strategies = new()
-        {
-            { ThermostatMode.Heat, new HeatModeStrategy() },
-            { ThermostatMode.Cool, new CoolModeStrategy() },
-            { ThermostatMode.Auto, new AutoModeStrategy() }
-        };
-    
-    private IThermostatModeStrategy _strategy;
-    
+            Strategies = new()
+            {
+                { ThermostatMode.Heat, new HeatModeStrategy() },
+                { ThermostatMode.Cool, new CoolModeStrategy() },
+                { ThermostatMode.Auto, new AutoModeStrategy() }
+            };
     
     // Required for EF Core
     private Thermostat()
@@ -56,7 +66,6 @@ public sealed class Thermostat : Device, IThermostatControllable
         Mode = ThermostatMode.Auto;
         DesiredTemperature = DefaultTemperature;
         AmbientTemperature = DefaultTemperature;
-        _strategy = Strategies[Mode];
     }
 
     public Thermostat(string name, string location)
@@ -66,7 +75,6 @@ public sealed class Thermostat : Device, IThermostatControllable
         Mode = ThermostatMode.Auto;
         DesiredTemperature = DefaultTemperature;
         AmbientTemperature = DefaultTemperature;
-        _strategy = Strategies[Mode];
     }
     
     /// <summary>
@@ -99,7 +107,6 @@ public sealed class Thermostat : Device, IThermostatControllable
     public void SetMode(ThermostatMode mode)
     {
         Mode = mode;
-        _strategy = Strategies[mode];
         
         if (State != ThermostatState.Off)
             EvaluateState();

--- a/backend/src/SmartHome.Domain/Device/Thermostat/Thermostat.cs
+++ b/backend/src/SmartHome.Domain/Device/Thermostat/Thermostat.cs
@@ -28,7 +28,7 @@ public sealed class Thermostat : Device, IThermostatControllable
         private set
         {
             if (!Enum.IsDefined<ThermostatMode>(value))
-                throw new ArgumentOutOfRangeException(nameof(value), 
+                throw new ArgumentOutOfRangeException(nameof(Mode), 
                     $"Unsupported thermostat mode: {value}.");
             _mode = value;
             _strategy = Strategies[value];

--- a/backend/src/SmartHome.Domain/Device/Thermostat/Thermostat.cs
+++ b/backend/src/SmartHome.Domain/Device/Thermostat/Thermostat.cs
@@ -27,6 +27,9 @@ public sealed class Thermostat : Device, IThermostatControllable
         get => _mode;
         private set
         {
+            if (!Enum.IsDefined(typeof(ThermostatMode), value))
+                throw new ArgumentOutOfRangeException(nameof(value), 
+                    $"Unsupported thermostat mode: {value}.");
             _mode = value;
             _strategy = Strategies[value];
         }

--- a/backend/src/SmartHome.Domain/Device/Thermostat/Thermostat.cs
+++ b/backend/src/SmartHome.Domain/Device/Thermostat/Thermostat.cs
@@ -27,7 +27,7 @@ public sealed class Thermostat : Device, IThermostatControllable
         get => _mode;
         private set
         {
-            if (!Enum.IsDefined(typeof(ThermostatMode), value))
+            if (!Enum.IsDefined<ThermostatMode>(value))
                 throw new ArgumentOutOfRangeException(nameof(value), 
                     $"Unsupported thermostat mode: {value}.");
             _mode = value;

--- a/backend/src/SmartHome.Domain/Device/Thermostat/Thermostat.cs
+++ b/backend/src/SmartHome.Domain/Device/Thermostat/Thermostat.cs
@@ -48,8 +48,8 @@ public sealed class Thermostat : Device, IThermostatControllable
 
     private IThermostatModeStrategy _strategy = null!;
     
-    // Strategy map — adding a new mode only requires a new class and entry here.
-    // Thermostat.cs never changes — Open/Closed Principle.
+    // To add a new mode: implement IThermostatModeStrategy and add an entry here.
+    // Thermostat's core logic never changes — Open/Closed Principle.
     private static readonly Dictionary<ThermostatMode, IThermostatModeStrategy>
             Strategies = new()
             {

--- a/backend/src/SmartHome.Domain/Device/Thermostat/Thermostat.cs
+++ b/backend/src/SmartHome.Domain/Device/Thermostat/Thermostat.cs
@@ -34,6 +34,20 @@ public sealed class Thermostat : Device, IThermostatControllable
     private const int MinTemperature = 60;
     private const int MaxTemperature = 80;
 
+    
+    // Strategy map — adding a new mode only requires a new class and entry here.
+    // Thermostat.cs never changes — Open/Closed Principle.
+    private static readonly Dictionary<ThermostatMode, IThermostatModeStrategy>
+        Strategies = new()
+        {
+            { ThermostatMode.Heat, new HeatModeStrategy() },
+            { ThermostatMode.Cool, new CoolModeStrategy() },
+            { ThermostatMode.Auto, new AutoModeStrategy() }
+        };
+    
+    private IThermostatModeStrategy _strategy;
+    
+    
     // Required for EF Core
     private Thermostat()
     {
@@ -42,6 +56,7 @@ public sealed class Thermostat : Device, IThermostatControllable
         Mode = ThermostatMode.Auto;
         DesiredTemperature = DefaultTemperature;
         AmbientTemperature = DefaultTemperature;
+        _strategy = Strategies[Mode];
     }
 
     public Thermostat(string name, string location)
@@ -51,6 +66,7 @@ public sealed class Thermostat : Device, IThermostatControllable
         Mode = ThermostatMode.Auto;
         DesiredTemperature = DefaultTemperature;
         AmbientTemperature = DefaultTemperature;
+        _strategy = Strategies[Mode];
     }
     
     /// <summary>
@@ -59,11 +75,10 @@ public sealed class Thermostat : Device, IThermostatControllable
     /// </summary>
     public void TurnOn()
     {
-        if (State == ThermostatState.Off)
-        {
-            State = ThermostatState.Idle;
-            EvaluateState();
-        }
+        if (State != ThermostatState.Off)
+            throw new InvalidOperationException("Thermostat is already on.");
+        State = ThermostatState.Idle;
+        EvaluateState();
     }
 
     
@@ -72,8 +87,9 @@ public sealed class Thermostat : Device, IThermostatControllable
     /// </summary>
     public void TurnOff()
     {
-        if (State != ThermostatState.Off)
-            State = ThermostatState.Off;
+        if (State == ThermostatState.Off)
+           throw new InvalidOperationException("Thermostat is already off.");
+        State = ThermostatState.Off;
     }
 
     
@@ -83,7 +99,8 @@ public sealed class Thermostat : Device, IThermostatControllable
     public void SetMode(ThermostatMode mode)
     {
         Mode = mode;
-
+        _strategy = Strategies[mode];
+        
         if (State != ThermostatState.Off)
             EvaluateState();
     }
@@ -140,43 +157,12 @@ public sealed class Thermostat : Device, IThermostatControllable
 
     
     /// <summary>
-    /// Evaluates the current ambient vs desired temperature and transitions
-    /// to the appropriate state based on the active mode.
+    /// Delegates evaluation to the active mode strategy.
     /// </summary>
     private void EvaluateState()
     {
-        if (State == ThermostatState.Off)
-            return;
-
-        if (AmbientTemperature == DesiredTemperature)
-        {
-            State = ThermostatState.Idle;
-            return;
-        }
-
-        switch (Mode)
-        {
-            case ThermostatMode.Heat:
-                State = AmbientTemperature < DesiredTemperature
-                    ? ThermostatState.Heating
-                    : ThermostatState.Idle;
-                break;
-
-            case ThermostatMode.Cool:
-                State = AmbientTemperature > DesiredTemperature
-                    ? ThermostatState.Cooling
-                    : ThermostatState.Idle;
-                break;
-
-            case ThermostatMode.Auto:
-                if (AmbientTemperature < DesiredTemperature)
-                    State = ThermostatState.Heating;
-                else if (AmbientTemperature > DesiredTemperature)
-                    State = ThermostatState.Cooling;
-                else
-                    State = ThermostatState.Idle;
-                break;
-        }
+        if (State == ThermostatState.Off) return;
+        State = _strategy.Evaluate(AmbientTemperature, DesiredTemperature);
     }
 
     

--- a/tests/SmartHome.Domain.Tests/Device/DoorLockTests.cs
+++ b/tests/SmartHome.Domain.Tests/Device/DoorLockTests.cs
@@ -1,4 +1,5 @@
 ﻿using SmartHome.Domain.Device;
+using SmartHome.Domain.Device.DoorLock;
 
 namespace SmartHome.Domain.Tests.Device;
 

--- a/tests/SmartHome.Domain.Tests/Device/FanTests.cs
+++ b/tests/SmartHome.Domain.Tests/Device/FanTests.cs
@@ -1,4 +1,5 @@
 ﻿using SmartHome.Domain.Device;
+using SmartHome.Domain.Device.Fan;
 
 namespace SmartHome.Domain.Tests.Device;
 

--- a/tests/SmartHome.Domain.Tests/Device/LightTests.cs
+++ b/tests/SmartHome.Domain.Tests/Device/LightTests.cs
@@ -1,4 +1,5 @@
 ﻿using SmartHome.Domain.Device;
+using SmartHome.Domain.Device.Light;
 
 
 namespace SmartHome.Domain.Tests.Device;

--- a/tests/SmartHome.Domain.Tests/Device/ThermostatTests.cs
+++ b/tests/SmartHome.Domain.Tests/Device/ThermostatTests.cs
@@ -411,7 +411,7 @@ public class ThermostatTests
     // Strategy pattern
     
     [Fact]
-    public void SetMode_WhenHeating_SwitchesToCoolMode_TransitionsToCooling()
+    public void SetMode_WhenHeating_SwitchesToCoolMode_TransitionsToIdle()
     {
         // Arrange
         var thermostat = CreateThermostatOn();

--- a/tests/SmartHome.Domain.Tests/Device/ThermostatTests.cs
+++ b/tests/SmartHome.Domain.Tests/Device/ThermostatTests.cs
@@ -407,4 +407,92 @@ public class ThermostatTests
         // Assert
         Assert.Equal(ThermostatState.Off, thermostat.State);
     }
+    
+    // Strategy pattern
+    
+    [Fact]
+    public void SetMode_WhenHeating_SwitchesToCoolMode_TransitionsToCooling()
+    {
+        // Arrange
+        var thermostat = CreateThermostatOn();
+        thermostat.SetMode(ThermostatMode.Heat);
+        thermostat.SetAmbientTemperature(65);
+        thermostat.SetDesiredTemperature(72);
+        // currently Heating
+
+        // Act — switch to Cool while ambient is still below desired
+        thermostat.SetMode(ThermostatMode.Cool);
+
+        // Assert — Cool mode won't heat, so transitions to Idle
+        Assert.Equal(ThermostatState.Idle, thermostat.State);
+    }
+    
+    [Fact]
+    public void SetMode_SwitchToAuto_ImmediatelyEvaluatesState()
+    {
+        // Arrange
+        var thermostat = CreateThermostatOn();
+        thermostat.SetMode(ThermostatMode.Heat);
+        thermostat.SetAmbientTemperature(65);
+        thermostat.SetDesiredTemperature(72);
+        // currently Heating in Heat mode
+
+        // Act — switch to Auto
+        thermostat.SetMode(ThermostatMode.Auto);
+
+        // Assert — Auto still sees ambient < desired, stays Heating
+        Assert.Equal(ThermostatState.Heating, thermostat.State);
+    }
+    
+    [Fact]
+    public void Tick_WhenAmbientEqualsDesired_DoesNotChangeAmbient()
+    {
+        // Arrange
+        var thermostat = CreateThermostatOn();
+        thermostat.SetMode(ThermostatMode.Heat);
+        thermostat.SetDesiredTemperature(72);
+        thermostat.SetAmbientTemperature(72);
+        // Idle — ambient equals desired
+
+        // Act
+        thermostat.Tick();
+
+        // Assert
+        Assert.Equal(72, thermostat.AmbientTemperature);
+    }
+    
+    [Fact]
+    public void TurnOn_AfterAmbientChangedWhileOff_EvaluatesCorrectly()
+    {
+        // Arrange
+        var thermostat = CreateThermostat();
+        thermostat.SetAmbientTemperature(65);
+        thermostat.SetDesiredTemperature(72);
+        // still Off, but ambient is below desired
+
+        // Act
+        thermostat.TurnOn();
+
+        // Assert — should immediately evaluate and start heating
+        Assert.Equal(ThermostatState.Heating, thermostat.State);
+    }
+    
+    [Fact]
+    public void Tick_MultipleTicksReachDesired_TransitionsToIdle()
+    {
+        // Arrange
+        var thermostat = CreateThermostatOn();
+        thermostat.SetMode(ThermostatMode.Heat);
+        thermostat.SetDesiredTemperature(72);
+        thermostat.SetAmbientTemperature(70);
+        // 2 degrees away
+
+        // Act
+        thermostat.Tick();
+        thermostat.Tick();
+
+        // Assert
+        Assert.Equal(ThermostatState.Idle, thermostat.State);
+        Assert.Equal(72, thermostat.AmbientTemperature);
+    }
 }

--- a/tests/SmartHome.Domain.Tests/Device/ThermostatTests.cs
+++ b/tests/SmartHome.Domain.Tests/Device/ThermostatTests.cs
@@ -1,4 +1,5 @@
 ﻿using SmartHome.Domain.Device;
+using SmartHome.Domain.Device.Thermostat;
 
 namespace SmartHome.Domain.Tests.Device;
 
@@ -71,17 +72,25 @@ public class ThermostatTests
     }
 
     [Fact]
-    public void TurnOn_WhenAlreadyOn_DoesNothing()
+    public void TurnOn_WhenAlreadyOn_Throws()
     {
         // Arrange
         var thermostat = CreateThermostatOn();
 
-        // Act
-        thermostat.TurnOn();
-
-        // Assert
-        Assert.Equal(ThermostatState.Idle, thermostat.State);
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => thermostat.TurnOn());
     }
+    
+    [Fact]
+    public void TurnOff_WhenAlreadyOff_Throws()
+    {
+        // Arrange
+        var thermostat = CreateThermostat();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => thermostat.TurnOff());
+    }
+    
 
     [Fact]
     public void TurnOff_WhenOn_TransitionsToOff()


### PR DESCRIPTION
- Add IThermostatModeStrategy interface defining mode evaluation contract
- Add HeatModeStrategy, CoolModeStrategy, AutoModeStrategy implementations
- Replace EvaluateState() switch statement with single-line strategy delegation
- Wire strategy map in both constructors and SetMode()
- TurnOn/TurnOff now throw on invalid transitions — no silent no-ops
- Fix TurnOn_WhenAlreadyOn_Throws test and add TurnOff_WhenAlreadyOff_Throws
- Add device-specific usings to all test files