### PR TITLE
Fix EF Core persistence, inheritance mapping, and add database seeding

### DIFF
--- a/backend/src/SmartHome.Api/Program.cs
+++ b/backend/src/SmartHome.Api/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
+using SmartHome.Domain.Device.Repository;
+using SmartHome.Infrastructure.Device.Repository;
 using SmartHome.Infrastructure.Persistence;
-// using SmartHome.Infrastructure.Persistence.Seed;
+using SmartHome.Infrastructure.Persistence.Seed;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,9 +15,11 @@ Directory.CreateDirectory(dataDirectory);
 
 var databasePath = Path.Combine(dataDirectory, "smarthome.db");
 
-
 builder.Services.AddDbContext<SmartHomeDbContext>(options =>
     options.UseSqlite($"Data Source={databasePath}"));
+
+builder.Services.AddScoped<IDeviceRepository, DeviceRepository>();
+builder.Services.AddScoped<SmartHomeDbSeeder>();
 
 var app = builder.Build();
 
@@ -26,19 +30,14 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-
 app.Logger.LogDebug("DB Path: {DatabasePath}", databasePath);
-
 
 using (var scope = app.Services.CreateScope())
 {
     var dbContext = scope.ServiceProvider.GetRequiredService<SmartHomeDbContext>();
-
-    
     await dbContext.Database.MigrateAsync();
 
-    
-    var seeder = new SmartHomeDbSeeder(dbContext);
+    var seeder = scope.ServiceProvider.GetRequiredService<SmartHomeDbSeeder>();
     await seeder.SeedAsync();
 }
 

--- a/backend/src/SmartHome.Domain/Device/Repository/IDeviceRepository.cs
+++ b/backend/src/SmartHome.Domain/Device/Repository/IDeviceRepository.cs
@@ -1,0 +1,46 @@
+using SmartHome.Domain.Device;
+
+namespace SmartHome.Domain.Device.Repository;
+
+/// <summary>
+/// Defines the persistence contract for smart home devices.
+/// Provides asynchronous access to query, add, remove, and persist devices
+/// without exposing infrastructure concerns such as EF Core to the domain or service layers.
+/// </summary>
+public interface IDeviceRepository
+{
+    /// <summary>
+    /// Retrieves all devices.
+    /// </summary>
+    Task<IReadOnlyList<Device>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a device by its unique identifier.
+    /// Returns null when no matching device exists.
+    /// </summary>
+    Task<Device?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a new device to persistence.
+    /// The change is not guaranteed to be committed until SaveChangesAsync is called.
+    /// </summary>
+    Task AddAsync(Device device, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes the device with the specified identifier.
+    /// Returns true when a device was found and marked for removal; otherwise false.
+    /// The change is not guaranteed to be committed until SaveChangesAsync is called.
+    /// </summary>
+    Task<bool> RemoveByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determines whether a thermostat already exists at the specified location.
+    /// Used to enforce one thermostat per location.
+    /// </summary>
+    Task<bool> ThermostatExistsAtLocationAsync(string location, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists all pending changes to the underlying storage medium.
+    /// </summary>
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/backend/src/SmartHome.Infrastructure/Device/Repository/DeviceRepository.cs
+++ b/backend/src/SmartHome.Infrastructure/Device/Repository/DeviceRepository.cs
@@ -1,0 +1,62 @@
+using Microsoft.EntityFrameworkCore;
+using DomainDevice = SmartHome.Domain.Device.Device;
+using SmartHome.Domain.Device.Repository;
+using SmartHome.Infrastructure.Persistence;
+
+namespace SmartHome.Infrastructure.Device.Repository;
+
+/// <summary>
+/// EF Core implementation of the device repository contract.
+/// Responsible only for persistence concerns for devices.
+/// </summary>
+public sealed class DeviceRepository : IDeviceRepository
+{
+    private readonly SmartHomeDbContext _dbContext;
+
+    public DeviceRepository(SmartHomeDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<DomainDevice>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Devices
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<DomainDevice?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Devices
+            .AsNoTracking()
+            .FirstOrDefaultAsync(device => device.Id == id, cancellationToken);
+    }
+
+    public async Task AddAsync(DomainDevice device, CancellationToken cancellationToken = default)
+    {
+        await _dbContext.Devices.AddAsync(device, cancellationToken);
+    }
+
+    public async Task<bool> RemoveByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        DomainDevice? device = await _dbContext.Devices
+            .FirstOrDefaultAsync(device => device.Id == id, cancellationToken);
+
+        if (device is null)
+            return false;
+
+        _dbContext.Devices.Remove(device);
+        return true;
+    }
+
+    public async Task<bool> ThermostatExistsAtLocationAsync(string location, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Thermostats
+            .AnyAsync(thermostat => thermostat.Location == location, cancellationToken);
+    }
+
+    public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/backend/src/SmartHome.Infrastructure/Persistence/Migrations/20260417195511_FixDeviceInheritance.Designer.cs
+++ b/backend/src/SmartHome.Infrastructure/Persistence/Migrations/20260417195511_FixDeviceInheritance.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SmartHome.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using SmartHome.Infrastructure.Persistence;
 namespace SmartHome.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SmartHomeDbContext))]
-    partial class SmartHomeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260417195511_FixDeviceInheritance")]
+    partial class FixDeviceInheritance
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.5");

--- a/backend/src/SmartHome.Infrastructure/Persistence/Migrations/20260417195511_FixDeviceInheritance.cs
+++ b/backend/src/SmartHome.Infrastructure/Persistence/Migrations/20260417195511_FixDeviceInheritance.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartHome.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixDeviceInheritance : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeviceType",
+                table: "Devices");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DeviceType",
+                table: "Devices",
+                type: "TEXT",
+                maxLength: 13,
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/backend/src/SmartHome.Infrastructure/Persistence/Seed/SmartHomeDbSeeder.cs
+++ b/backend/src/SmartHome.Infrastructure/Persistence/Seed/SmartHomeDbSeeder.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using SmartHome.Domain.Device.DoorLock;
+using SmartHome.Domain.Device.Fan;
+using SmartHome.Domain.Device.Light;
+using SmartHome.Domain.Device.Thermostat;
+using DomainDevice = SmartHome.Domain.Device.Device;
+
+namespace SmartHome.Infrastructure.Persistence.Seed;
+
+public sealed class SmartHomeDbSeeder
+{
+    private readonly SmartHomeDbContext _dbContext;
+
+    public SmartHomeDbSeeder(SmartHomeDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task SeedAsync(CancellationToken cancellationToken = default)
+    {
+        if (await _dbContext.Devices.AnyAsync(cancellationToken))
+            return;
+
+        var devices = new DomainDevice[]
+        {
+            new DoorLock("Front Door", "Entryway"),
+            new DoorLock("Back Door", "Patio"),
+            new Fan("Living Room Fan", "Living Room"),
+            new Fan("Bedroom Fan", "Bedroom"),
+            new Light("Kitchen Overhead", "Kitchen"),
+            new Light("Living Room Overhead", "Living Room"),
+            new Thermostat("Living Room Thermostat", "Living Room")
+        };
+
+        await _dbContext.Devices.AddRangeAsync(devices, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/backend/src/SmartHome.Infrastructure/Persistence/SmartHomeDbContext.cs
+++ b/backend/src/SmartHome.Infrastructure/Persistence/SmartHomeDbContext.cs
@@ -1,20 +1,20 @@
 using Microsoft.EntityFrameworkCore;
-using SmartHome.Domain.Device.Light;
-using SmartHome.Domain.Device.Fan;
-using SmartHome.Domain.Device.Thermostat;
-using SmartHome.Domain.Device.DoorLock;
 using SmartHome.Domain.Device;
+using SmartHome.Domain.Device.DoorLock;
+using SmartHome.Domain.Device.Fan;
+using SmartHome.Domain.Device.Light;
+using SmartHome.Domain.Device.Thermostat;
+using DomainDevice = SmartHome.Domain.Device.Device;
 
 namespace SmartHome.Infrastructure.Persistence;
 
 public sealed class SmartHomeDbContext : DbContext
 {
-    public SmartHomeDbContext(DbContextOptions<SmartHomeDbContext> options)
-        : base(options)
+    public SmartHomeDbContext(DbContextOptions<SmartHomeDbContext> options) : base(options)
     {
     }
 
-    public DbSet<Device> Devices => Set<Device>();
+    public DbSet<DomainDevice> Devices => Set<DomainDevice>();
     public DbSet<Light> Lights => Set<Light>();
     public DbSet<Fan> Fans => Set<Fan>();
     public DbSet<Thermostat> Thermostats => Set<Thermostat>();
@@ -22,7 +22,7 @@ public sealed class SmartHomeDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<Device>()
+        modelBuilder.Entity<DomainDevice>()
             .HasDiscriminator(device => device.Type)
             .HasValue<Light>(DeviceType.Light)
             .HasValue<Fan>(DeviceType.Fan)


### PR DESCRIPTION
## Summary
- restore EF Core persistence after file loss
- fix device inheritance mapping with TPH discriminator
- add repository interface and EF repository implementation
- add idempotent database seeding on startup
- add migration updates for current model

## Verified
- dotnet build SmartHome.sln passes
- API starts successfully
- migrations apply on startup
- database seeds expected smart home devices