### PR TITLE
ci: cache NuGet packages in backend workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,6 +29,14 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/packages.lock.json', '**/nuget.config') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Restore backend
         run: dotnet restore SmartHome.sln
 


### PR DESCRIPTION
- Added NuGet package caching to backend CI job
- Uses actions/cache@v4
- Cache key invalidates on .csproj, packages.lock.json, or nuget.config changes
- Improves pipeline performance by avoiding redundant package restores